### PR TITLE
Use TableView.showStandupPrompt instead of command app.leaveTable

### DIFF
--- a/js/popups/tablemenupopup.ts
+++ b/js/popups/tablemenupopup.ts
@@ -227,7 +227,7 @@ export class TableMenuPopup {
     leave() {
         let index = tableManager.currentIndex();
         let tableView = tableManager.tables()[index];
-        commandManager.executeCommand("app.leaveTable", [tableView.tableId]);
+        tableView.showStandupPrompt();
     }
     private getCurrentMoney(tournament: TournamentView, personalAccount: PersonalAccountData) {
         return personalAccount.RealMoney;


### PR DESCRIPTION
When using command application clear table from list of opened tables, which is not needed in the game console mode.