### PR TITLE
Clear terminated status in the failed connection handler

### DIFF
--- a/js/services/connectionwrapper.ts
+++ b/js/services/connectionwrapper.ts
@@ -275,6 +275,11 @@ export class ConnectionWrapper {
         }).then(null, (message: string = "") => {
             this.logEvent("Could not Connect!" + message);
             timeService.setTimeout(() => {
+                if (this.terminated) {
+                    this.logEvent("Reset terminate status for connection before attemt to try new connection");
+                    this.terminated = false;
+                }
+
                 this.establishConnection(maxAttempts - 1).then(() => {
                     result.resolve(this);
                 }, () => {


### PR DESCRIPTION
Log this scenarion so we could trobleshoot in case if this will have some unexpected consequences. I implement this since when first connection was not successful, it never attempt to rec
onnect again since connection was terminated.