### PR TITLE
Prevent check from executing when it is not player's turn

### DIFF
--- a/js/table/actionBlock.ts
+++ b/js/table/actionBlock.ts
@@ -568,7 +568,7 @@ export class ActionBlock {
         this.checkOrCallExecuted.dispatch();
     }
     async check() {
-        if (this.isCheck()) {
+        if (this.isCheck() && !this.notMyTurn()) {
             this.tableView.checkOrCall();
             this.expanded(false);
             this.checkOrCallExecuted.dispatch();


### PR DESCRIPTION
The `check` function is bound to double table in the UI and when execute operation not in player's turn it lead to error popup appearing on the screen
 