### PR TITLE
Add back lint checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ node_js:
   - 8
 script:
   - npm run test
+  - npm run lint
 after_success:
   - npm run report-coverage


### PR DESCRIPTION
It was incidently removed from the check when npm test was replaced with jest