### PR TITLE
Add global prefix for code

### DIFF
--- a/js/tabbar.ts
+++ b/js/tabbar.ts
@@ -1,6 +1,5 @@
-﻿/// <reference types="knockout" />
-
-import { debugSettings } from "./debugsettings";
+﻿import * as ko from "knockout";
+import { debugSettings } from "poker/debugsettings";
 
 class TabBarItem {
     public name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,12 @@
       "es2015.core"
     ],
   "out": "js/application.js",
-  "sourceRoot": "."
+  "sourceRoot": ".",
+  "baseUrl": ".",
+  "rootDir": ".",
+  "paths": {
+      "poker/*": ["js/*"]
+  }
  },
  "compileOnSave": false,
  "exclude": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = (env) => {
         resolve: {
             extensions: ['.js', '.jsx', '.ts', '.tsx'],
             alias: {
-                "app": path.join(__dirname, "js"),
+                "poker": path.join(__dirname, "js"),
             }
         },
         externals: {


### PR DESCRIPTION
This global prefixig allow better refactoring across codebase when imports could be just copied from anywhere without adjustments to location of file where it is inserted. Also lead to more cleaner usage inside tests and examples