### PR TITLE
Add support for the 1280 pixel wide screens

### DIFF
--- a/js/pages/tablespage.ts
+++ b/js/pages/tablespage.ts
@@ -163,6 +163,10 @@ export class TablesPage extends PageBase {
         const currentWidth = $("body").width();
         if (currentWidth >= 1024 || (currentWidth === 768 && $("body").height() === 0)) {
             viewportLandscapeWidth = 1024;
+            if (currentWidth >= 1280) {
+                viewportLandscapeWidth = 1280;
+            }
+
             if (currentWidth >= 1920) {
                 viewportLandscapeWidth = 1920;
             }


### PR DESCRIPTION
This resolution is middle ground for supporting of the desktops. Strategy for UI is to use breakpoints for the desktop application, and 1280 is first of many others which will be added. Adding support to the JS is require to have support in the CSS side, since adding not supported by CSS resolutions will lead to UX issues when performing switch between tables