### PR TITLE
Rename packed output file to poker-html-client

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = (env) => {
     const isDevBuild = !(env && env.prod);
     return [{
         stats: { modules: false },
-        entry: { 'main': './js/appInit' },
+        entry: { 'poker-html-client': './js/appInit' },
         resolve: {
             extensions: ['.js', '.jsx', '.ts', '.tsx'],
             alias: {


### PR DESCRIPTION
This make library code be more reusable and simplify logical connection when used in the complicated builds, where generic name main.js could lead to confusion.