### PR TITLE
Apply configuration override to sound manager

### DIFF
--- a/js/app.ts
+++ b/js/app.ts
@@ -43,13 +43,13 @@ import { Selector, SelectorItem } from "./selector";
 import {
     connectionService,
     deviceEvents,
+    getSoundManager,
     imagePreloadService,
     keyboardActivationService,
     orientationService,
     pushService,
     reloadManager,
     slowInternetService,
-    soundManager,
     WebsiteService,
 } from "./services";
 import * as broadcastService from "./services/broadcastservice";
@@ -296,6 +296,7 @@ export class App {
         const self = this;
         timeService.start();
         settings.soundEnabled.subscribe(function(value) {
+            const soundManager = getSoundManager();
             soundManager.enabled(value);
         });
         settings.loadSettings();

--- a/js/pages/SeatPage.ts
+++ b/js/pages/SeatPage.ts
@@ -8,9 +8,9 @@ import { PageBlock } from "../pageblock";
 import {
     connectionService,
     deviceEvents,
+    getSoundManager,
     orientationService,
     reloadManager,
-    soundManager,
 } from "../services";
 import { uiManager } from "../services/uimanager";
 import { settings } from "../settings";
@@ -228,6 +228,7 @@ export class SeatPage extends PageBase {
         /* tslint:disable:no-string-literal no-unused-expression */
         window["StatusBar"] && StatusBar.show();
         /* tslint:enable:no-string-literal no-unused-expression */
+        const soundManager = getSoundManager();
         soundManager.tableSoundsEnabled(false);
         if (!PageBlock.useDoubleView) {
             orientationService.setOrientation("portrait");
@@ -256,6 +257,7 @@ export class SeatPage extends PageBase {
         /* tslint:disable:no-string-literal no-unused-expression */
         window["StatusBar"] && StatusBar.hide();
         /* tslint:enable:no-string-literal no-unused-expression */
+        const soundManager = getSoundManager();
         if (appConfig.game.seatMode) {
             soundManager.enabled(false);
         } else {

--- a/js/pages/tablespage.ts
+++ b/js/pages/tablespage.ts
@@ -8,9 +8,9 @@ import { PageBlock } from "../pageblock";
 import {
     connectionService,
     deviceEvents,
+    getSoundManager,
     orientationService,
     reloadManager,
-    soundManager,
 } from "../services";
 import { uiManager } from "../services/uimanager";
 import { settings } from "../settings";
@@ -230,6 +230,7 @@ export class TablesPage extends PageBase {
         /* tslint:disable:no-string-literal no-unused-expression */
         window["StatusBar"] && StatusBar.show();
         /* tslint:enable:no-string-literal no-unused-expression */
+        const soundManager = getSoundManager();
         soundManager.tableSoundsEnabled(false);
         if (!PageBlock.useDoubleView) {
             orientationService.setOrientation("portrait");
@@ -258,6 +259,7 @@ export class TablesPage extends PageBase {
         /* tslint:disable:no-string-literal no-unused-expression */
         window["StatusBar"] && StatusBar.hide();
         /* tslint:enable:no-string-literal no-unused-expression */
+        const soundManager = getSoundManager();
         if (appConfig.game.seatMode) {
             soundManager.enabled(false);
         } else {

--- a/js/services/index.ts
+++ b/js/services/index.ts
@@ -12,6 +12,15 @@ import { SlowInternetService } from "./slowinternetservice";
 import { SoundManager } from "./soundmanager";
 export { WebsiteService } from "./websiteService";
 
+let soundManager: SoundManager;
+export function getSoundManager() {
+    if (!soundManager) {
+        soundManager = new SoundManager(appConfig.game.soundTheme, appConfig.game.hasHumanVoice);
+    }
+
+    return soundManager;
+}
+
 export let keyboardActivationService = new KeyboardActivationService();
 export let slowInternetService = new SlowInternetService();
 export let connectionService = new ConnectionService();
@@ -19,7 +28,6 @@ export let accountService = new AccountService(true, false);
 export let imagePreloadService = new ImagePreloadService();
 export let reloadManager = new ReloadManager();
 export let deviceEvents = new DeviceEventService();
-export let soundManager = new SoundManager(appConfig.game.soundTheme, appConfig.game.hasHumanVoice);
 export let orientationService = new OrientationService();
 export let pushService = new PushService();
 export const appReloadService = new AppReloadService();

--- a/js/table/tableview.ts
+++ b/js/table/tableview.ts
@@ -10,7 +10,7 @@ import { debugSettings } from "../debugsettings";
 import { withCommas } from "../helpers";
 import { _ } from "../languagemanager";
 import { SimplePopup } from "../popups/simplepopup";
-import { connectionService, slowInternetService, soundManager } from "../services";
+import { connectionService, getSoundManager, slowInternetService } from "../services";
 import { ConnectionWrapper } from "../services/connectionwrapper";
 import { SlowInternetService } from "../services/slowinternetservice";
 import { settings } from "../settings";
@@ -742,10 +742,12 @@ export class TableView {
                 if (self.timeLeft() === 7) {
                     if (self.currentPlayer() === self.myPlayer()) {
                         if (self.soundEnabled) {
+                            const soundManager = getSoundManager();
                             soundManager.playTurnReminder();
                         }
                     } else {
                         if (self.soundEnabled) {
+                            const soundManager = getSoundManager();
                             soundManager.playTurnReminderForAll();
                         }
                     }
@@ -1395,6 +1397,7 @@ export class TableView {
 
                 const c = this.calculateWinnerAmount(places, winners, needHightlightCards);
                 if (self.soundEnabled) {
+                    const soundManager = getSoundManager();
                     soundManager.playWinChips();
                 }
 
@@ -1470,6 +1473,7 @@ export class TableView {
                         const potWinners = winners.filter((winner) => winner.Pot === potNumber);
                         const c = this.calculateWinnerAmount(places, potWinners, needHightlightCards);
                         if (this.soundEnabled) {
+                            const soundManager = getSoundManager();
                             soundManager.playWinChips();
                         }
 
@@ -2178,18 +2182,21 @@ export class TableView {
             if (currentCardsOpened === 0 && cards.length === 3) {
                 self.handHistory.onFlop(cards[0], cards[1], cards[2]);
                 self.actionBlock.dealsAllowed(true);
+                const soundManager = getSoundManager();
                 soundManager.playFlopCards();
                 self.onFlopDealed.dispatch(this.tableId);
             }
             if (currentCardsOpened === 3 && cards.length === 4) {
                 self.handHistory.onTurn(cards[3]);
                 self.actionBlock.dealsAllowed(true);
+                const soundManager = getSoundManager();
                 soundManager.playTurn();
                 self.onTurnDealed.dispatch(this.tableId);
             }
             if (currentCardsOpened === 4 && cards.length === 5) {
                 self.handHistory.onRiver(cards[4]);
                 self.actionBlock.dealsAllowed(true);
+                const soundManager = getSoundManager();
                 soundManager.playRiver();
                 self.onRiverDealed.dispatch(this.tableId);
             }
@@ -2208,6 +2215,7 @@ export class TableView {
             self.actionBlock.updateAdditionalButtons();
         });
         if (self.soundEnabled) {
+            const soundManager = getSoundManager();
             soundManager.playFlop();
         }
 
@@ -2637,6 +2645,7 @@ export class TableView {
         });
         this.setButtons(dealerSeat);
         if (this.soundEnabled) {
+            const soundManager = getSoundManager();
             soundManager.playDealCards();
         }
 
@@ -2932,6 +2941,7 @@ export class TableView {
             currentPlayer.startAction("table.actiontext.fold");
             this.handHistory.onFold(playerId);
             if (this.soundEnabled) {
+                const soundManager = getSoundManager();
                 soundManager.playFold();
             }
         } else if (type === 2) {
@@ -2940,6 +2950,7 @@ export class TableView {
                 currentPlayer.startAction("table.actiontext.allin");
                 this.handHistory.onAllIn(playerId, amount);
                 if (this.soundEnabled) {
+                    const soundManager = getSoundManager();
                     soundManager.playAllIn();
                 }
             } else {
@@ -2947,12 +2958,14 @@ export class TableView {
                     currentPlayer.startAction("table.actiontext.check");
                     this.handHistory.onCheck(playerId, amount);
                     if (this.soundEnabled) {
+                        const soundManager = getSoundManager();
                         soundManager.playCheck();
                     }
                 } else {
                     currentPlayer.startAction("table.actiontext.call");
                     this.handHistory.onCall(playerId, amount);
                     if (this.soundEnabled) {
+                        const soundManager = getSoundManager();
                         soundManager.playCall();
                     }
                 }
@@ -2963,6 +2976,7 @@ export class TableView {
                 currentPlayer.startAction("table.actiontext.allin");
                 this.handHistory.onAllIn(playerId, amount);
                 if (this.soundEnabled) {
+                    const soundManager = getSoundManager();
                     soundManager.playAllIn();
                 }
             } else {
@@ -2970,12 +2984,14 @@ export class TableView {
                     currentPlayer.startAction("table.actiontext.bet");
                     this.handHistory.onBet2(playerId, amount);
                     if (this.soundEnabled) {
+                        const soundManager = getSoundManager();
                         soundManager.playBet();
                     }
                 } else {
                     currentPlayer.startAction("table.actiontext.raise");
                     this.handHistory.onRaise(playerId, amount);
                     if (this.soundEnabled) {
+                        const soundManager = getSoundManager();
                         soundManager.playRaise();
                     }
                 }


### PR DESCRIPTION
Due to way how it was initialized, the configuration override was not applied, since SoundManager instance was initialized earlier. So was created function getSoundManager which should return global instance of the sound manager on first request