### PR TITLE
Add ability to control hiding of current combination

### DIFF
--- a/js/appconfig.ts
+++ b/js/appconfig.ts
@@ -40,6 +40,7 @@ export class AppConfig {
         hasPageReload: false,
         soundTheme: "poker",
         hasHumanVoice: true,
+        cardsOverlaySupported: true,
     };
     public tournament = {
         enabled: false,

--- a/js/table/tableview.ts
+++ b/js/table/tableview.ts
@@ -71,6 +71,7 @@ export class TableView {
     public nextGameAnte: KnockoutObservable<number> = ko.observable(0);
     public nextGameInformation: KnockoutComputed<string>;
     public nextGameTypeInformation: KnockoutComputed<string>;
+    public currentCombinationVisible: KnockoutComputed<boolean>;
     /**
      * Minimal amount of money which currently authenticated player
      * could bring on the table if he stand up from the table lately.
@@ -711,6 +712,17 @@ export class TableView {
             const tableTotal = totalBet + me.Money() + me.Bet();
             return (20 * baseMinimalBuyIn) > tableTotal;
         }, this);
+        this.currentCombinationVisible = ko.computed(() => {
+            if (!this.myPlayer()) {
+                return false;
+            }
+
+            if (!appConfig.game.cardsOverlaySupported) {
+                return true;
+            }
+
+            return !this.myPlayer().cardsOverlayVisible();
+        });
 
         this.actionBlock.attach(this);
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "coverageThreshold": {
       "global": {
         "branches": 34,
-        "functions": 39,
+        "functions": 40,
         "lines": 47,
         "statements": 47
       }

--- a/tests/table/playerCards.test.ts
+++ b/tests/table/playerCards.test.ts
@@ -1,0 +1,100 @@
+import { appConfig, overrideConfiguration } from "poker/appconfig";
+import {
+    login,
+    loginId,
+} from "poker/authmanager";
+import { ActionBlock } from "poker/table/actionBlock";
+import { drainQueue, getTable, getTestTableView, simpleInitialization } from "./helper";
+
+const logEnabled = false;
+const log = function (message: string, ...params: any[]) {
+    if (logEnabled) {
+        console.log(message);
+    }
+};
+
+async function playUntilFlop(playerId: number) {
+    const tableModel = getTable();
+    const view1 = getTestTableView();
+    const actionBlock = view1.actionBlock;
+    await simpleInitialization(view1, 1, [4288, 138981]);
+    expect(view1.myPlayer() != null).toBeTruthy();
+    loginId(playerId);
+    view1.currentLogin(`Player${playerId}`);
+    // blinds
+    log("Blinds round started");
+    view1.onBet(1, 0, 10, 2);
+    view1.onBet(2, 0, 20, 1);
+    view1.onPlayerCards(1, [1, 2]);
+    // preflop
+    log("Preflop round started");
+    view1.onBet(1, 2, 20, 2);
+    view1.onBet(2, 2, 20, 1);
+    view1.executeMoveMoneyToPot([40]);
+    view1.onOpenCards([3, 4, 5]);
+    await drainQueue(view1.queue);
+    return view1;
+}
+
+describe("Player cards", function () {
+    beforeAll(() => {
+        global.messages = {
+        };
+    });
+    describe("Overlay cards supported", function () {
+        beforeAll(() => {
+            overrideConfiguration({
+                game: {
+                    cardsOverlaySupported: true,
+                },
+            });
+        });
+
+        it("If player not in game current combination does not displayed", async function () {
+            const view = await playUntilFlop(3);
+            expect(view.myPlayer()).toBeNull();
+            expect(view.currentCombinationVisible()).toEqual(false);
+        });
+
+        it("If player has overlay opened, combination not visible", async function () {
+            const view = await playUntilFlop(1);
+            expect(view.myPlayer()).not.toBeNull();
+            expect(view.currentCombinationVisible()).toEqual(false);
+        });
+
+        it("If player hide overlay, combination is visible", async function () {
+            const view = await playUntilFlop(1);
+            expect(view.myPlayer()).not.toBeNull();
+            view.myPlayer().cardsOverlayVisible(false);
+            expect(view.currentCombinationVisible()).toEqual(true);
+        });
+    });
+    describe("Overlay cards not supported", function () {
+        beforeAll(() => {
+            overrideConfiguration({
+                game: {
+                    cardsOverlaySupported: false,
+                },
+            });
+        });
+
+        it("If player not in game current combination does not displayed", async function () {
+            const view = await playUntilFlop(3);
+            expect(view.myPlayer()).toBeNull();
+            expect(view.currentCombinationVisible()).toEqual(false);
+        });
+
+        it("If player has overlay opened, combination not visible", async function () {
+            const view = await playUntilFlop(1);
+            expect(view.myPlayer()).not.toBeNull();
+            expect(view.currentCombinationVisible()).toEqual(true);
+        });
+
+        it("If player hide overlay, combination is visible", async function () {
+            const view = await playUntilFlop(1);
+            expect(view.myPlayer()).not.toBeNull();
+            view.myPlayer().cardsOverlayVisible(false);
+            expect(view.currentCombinationVisible()).toEqual(true);
+        });
+    });
+});


### PR DESCRIPTION
When running with cards overlay, displaying current combination
exposes player cards and could lead to loss of hist money, if somebody
around saw them, and pass that information to player's opponent somehow.