### PR TITLE
Add tests for the rebuy/addon buttons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
   - 8
 script:
   - npm run test
-  - npm run lint
+  - npm run lint:test
 before_install:
 - printf "@poker:registry=https://pokerkz.pkgs.visualstudio.com/_packaging/50dc0ca2-b4b7-4773-922d-1f1486f9c8c8/npm/registry/\n" >> ~/.npmrc
 - printf "//pokerkz.pkgs.visualstudio.com/_packaging/50dc0ca2-b4b7-4773-922d-1f1486f9c8c8/npm/registry/:_authToken=${NPM_TOKEN}\n" >> ~/.npmrc

--- a/build-tsconfig.json
+++ b/build-tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "amd",
+    "out": "js/application.js",
+  },
+ "compileOnSave": false,
+ "exclude": [
+     "js/messages.ts",
+     "node_modules",
+     "tests"
+ ]
+}

--- a/js/app.ts
+++ b/js/app.ts
@@ -1,5 +1,6 @@
 import { getAuthToken, setAuthToken } from "@poker/api-server";
 import * as $ from "jquery";
+import { AccountManager } from "poker/services/accountManager";
 import "signalr";
 import * as signals from "signals";
 import * as authManager from "./authmanager";
@@ -61,7 +62,6 @@ import { AnimationSettings } from "./table/animationsettings";
 import * as runtimeSettings from "./table/runtimesettings";
 import { tableManager } from "./table/tablemanager";
 import * as timeService from "./timeservice";
-import { AccountManager } from "poker/services/accountManager";
 
 type PromiseOrVoid = void | Promise<void>;
 

--- a/js/appconfig.ts
+++ b/js/appconfig.ts
@@ -99,7 +99,11 @@ function mergeDeep(target, ...sources) {
     return mergeDeep(target, ...sources);
 }
 
-export function overrideConfiguration(localConfiguration: Partial<AppConfig>) {
+export type PartialConfiguration<T> = {
+    [P in keyof T]?: Partial<T[P]>;
+};
+
+export function overrideConfiguration(localConfiguration: PartialConfiguration<AppConfig>) {
     appConfig = mergeDeep(appConfig, localConfiguration);
 }
 

--- a/js/authmanager.ts
+++ b/js/authmanager.ts
@@ -3,11 +3,8 @@ declare var appInsights: Client;
 
 import { Account, setAuthToken } from "@poker/api-server";
 import ko = require("knockout");
-import { App } from "./app";
 import { appConfig } from "./appconfig";
 import { settings } from "./settings";
-
-declare const app: App;
 
 class AuthManager {
     public authenticated: KnockoutObservable<boolean>;
@@ -80,7 +77,6 @@ class AuthManager {
                 settings.login(value.Login);
                 settings.password(value.Password);
                 settings.saveSettings();
-                app.processing(false);
                 if (value.Status === "Ok") {
                     return await this.authenticate(value.Login, value.Password, true);
                 } else {

--- a/js/commandmanager.ts
+++ b/js/commandmanager.ts
@@ -1,7 +1,25 @@
 
-type CommandHandler = (params?: any[]) => any;
+export type CommandHandler = (params?: any[]) => any;
 
-class CommandManager {
+export interface ICommandExecutor {
+    /**
+     * Executes command by name, optionally pass arguments to it.
+     * @param commandName Name of the command to execute.
+     * @param parameters Optional parameters to pass in the command.
+     */
+    executeCommand(commandName: string, parameters?: any[]): any;
+}
+
+export interface ICommandManager extends ICommandExecutor {
+    /**
+     * Register command with given name for execution.
+     * @param commandName Name of the command to register.
+     * @param handler Handler to execute by the command.
+     */
+    registerCommand(commandName: string, handler: CommandHandler): void;
+}
+
+export class CommandManager implements ICommandManager {
     public commands: any[] = [];
 
     public registerCommand(commandName: string, handler: CommandHandler): void {
@@ -19,5 +37,4 @@ class CommandManager {
     }
 }
 
-const commandManager = new CommandManager();
-export = commandManager;
+export const commandManager = new CommandManager();

--- a/js/pages/SeatPage.ts
+++ b/js/pages/SeatPage.ts
@@ -1,8 +1,8 @@
 ﻿import * as $ from "jquery";
 import * as ko from "knockout";
+import { ICommandExecutor } from "poker/commandmanager";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as commandManager from "../commandmanager";
 import { debugSettings } from "../debugsettings";
 import { PageBlock } from "../pageblock";
 import {
@@ -45,7 +45,8 @@ export class SeatPage extends PageBase {
     public nextGameTypeInformation: KnockoutComputed<string>;
     public splashShown = ko.observable(false);
     public tablesShown = ko.observable(true);
-    constructor() {
+
+    constructor(private commandExecutor: ICommandExecutor) {
         super();
         const self = this;
         this.slideWidth = ko.observable(0);
@@ -310,7 +311,7 @@ export class SeatPage extends PageBase {
                 self.deactivate();
             }
         };
-        const leaved = commandManager.executeCommand("app.leaveTable", [tableView.tableId]) as JQueryDeferred<() => void>;
+        const leaved = this.commandExecutor.executeCommand("app.leaveTable", [tableView.tableId]) as JQueryDeferred<() => void>;
         leaved.then(removeCurrentTable);
     }
     public showMenu() {

--- a/js/pages/tablespage.ts
+++ b/js/pages/tablespage.ts
@@ -1,14 +1,15 @@
 ﻿import * as $ from "jquery";
 import * as ko from "knockout";
+import { ICommandExecutor } from "poker/commandmanager";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as commandManager from "../commandmanager";
 import { debugSettings } from "../debugsettings";
 import { PageBlock } from "../pageblock";
 import {
     connectionService,
     deviceEvents,
     getSoundManager,
+    ICurrentTableProvider,
     orientationService,
     reloadManager,
 } from "../services";
@@ -21,7 +22,7 @@ import { PageBase } from "../ui/pagebase";
 
 declare var app: App;
 
-export class TablesPage extends PageBase {
+export class TablesPage extends PageBase implements ICurrentTableProvider {
     public currentTable: KnockoutComputed<TableView>;
     public selectedTables: KnockoutComputed<TableView[]>;
     public currentIndex: KnockoutComputed<number>;
@@ -43,7 +44,8 @@ export class TablesPage extends PageBase {
     public nextGameTypeInformation: KnockoutComputed<string>;
     public splashShown = ko.observable(false);
     public tablesShown = ko.observable(true);
-    constructor() {
+
+    constructor(private commandExecutor: ICommandExecutor) {
         super();
         const self = this;
         this.slideWidth = ko.observable(0);
@@ -316,7 +318,7 @@ export class TablesPage extends PageBase {
                 self.deactivate();
             }
         };
-        const leaved = commandManager.executeCommand("app.leaveTable", [tableView.tableId]) as JQueryDeferred<() => void>;
+        const leaved = this.commandExecutor.executeCommand("app.leaveTable", [tableView.tableId]) as JQueryDeferred<() => void>;
         leaved.then(removeCurrentTable);
     }
     public showMenu() {

--- a/js/popups/tablemenupopup.ts
+++ b/js/popups/tablemenupopup.ts
@@ -1,6 +1,5 @@
 /* tslint:disable:no-bitwise */
-import { PersonalAccountData } from "@poker/api-server";
-import { TournamentOptionsEnum } from "@poker/api-server";
+import { PersonalAccountData, TournamentOptionsEnum } from "@poker/api-server";
 import * as ko from "knockout";
 import { ICommandExecutor } from "poker/commandmanager";
 import { ICurrentTableProvider } from "poker/services";

--- a/js/services/accountManager.ts
+++ b/js/services/accountManager.ts
@@ -1,7 +1,11 @@
-import { Account } from "@poker/api-server";
+import { Account, PersonalAccountData } from "@poker/api-server";
 declare var host: string;
 
-export class AccountManager {
+export interface IAccountManager {
+    getAccount(): Promise<ApiResult<PersonalAccountData>>;
+}
+
+export class AccountManager implements IAccountManager {
     public async getAccount() {
         const api = new Account(host);
         return api.getAccount();

--- a/js/services/index.ts
+++ b/js/services/index.ts
@@ -1,3 +1,4 @@
+import { TableView } from "poker/table/tableview";
 import { appConfig } from "../appconfig";
 import { AccountService } from "./accountservice";
 import { AppReloadService } from "./appreloadservice";
@@ -31,3 +32,7 @@ export let deviceEvents = new DeviceEventService();
 export let orientationService = new OrientationService();
 export let pushService = new PushService();
 export const appReloadService = new AppReloadService();
+
+export interface ICurrentTableProvider {
+    currentTable(): TableView;
+}

--- a/js/table/tablemanager.ts
+++ b/js/table/tablemanager.ts
@@ -7,10 +7,10 @@ import {
 } from "@poker/api-server";
 import * as ko from "knockout";
 import { DefaultApiProvider, IApiProvider } from "poker/api";
+import { commandManager } from "poker/commandmanager";
 import * as signals from "signals";
 import { appConfig } from "../appconfig";
 import * as authManager from "../authmanager";
-import * as commandManager from "../commandmanager";
 import { debugSettings } from "../debugsettings";
 import { _ } from "../languagemanager";
 import { SimplePopup } from "../popups/simplepopup";

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "HTML client for online poker",
   "main": "dist/poker-html-client.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc --project build-tsconfig.json",
     "lint": "tslint --project tsconfig.json",
+    "lint:test": "tslint --project test-tsconfig.json",
     "tslint": "tslint",
     "configure-ci": "node build/configure-ci.js",
     "build": "npm run webpack && npm run lint",
@@ -48,7 +49,8 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^poker/(.*)": "<rootDir>/js/$1"
+      "^poker/(.*)": "<rootDir>/js/$1",
+      "^tests/(.*)": "<rootDir>/tests/$1"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
@@ -56,10 +58,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 34,
-        "functions": 40,
-        "lines": 47,
-        "statements": 47
+        "branches": 36,
+        "functions": 41,
+        "lines": 48,
+        "statements": 48
       }
     },
     "collectCoverage": true,

--- a/tests/popups/tablemenupopup.test.ts
+++ b/tests/popups/tablemenupopup.test.ts
@@ -1,0 +1,619 @@
+import { PersonalAccountData, TournamentOptionsEnum, Account } from "@poker/api-server";
+import { TableMenuPopup } from "poker/popups";
+import { IAccountManager } from "poker/services/accountManager";
+import { getTestTableView, getTestTournamentTableView, simpleInitialization } from "tests/table/helper";
+
+const defaultPersonalAccountData = {
+    RealMoney: 0,
+    RealMoneyReserve: 0,
+    GameMoney: 0,
+    GameMoneyReserve: 0,
+    Points: 0,
+    LastIncomeDate: "",
+    LastIncomeAmount: 0,
+    LastRequestNumber: 0,
+};
+
+function getAccount(baseData?: Partial<PersonalAccountData>) {
+    const data: ApiResult<PersonalAccountData> = {
+        Status: "Ok",
+        Data: Object.assign({}, defaultPersonalAccountData, baseData || {}),
+    };
+    return Promise.resolve(data);
+}
+
+function getAccountManager(): IAccountManager {
+    return {
+        getAccount,
+    };
+}
+
+describe("Table menu", function () {
+    beforeAll(() => {
+        global.messages = {
+        };
+    });
+    describe("rebuy button", function () {
+        it("rebuy button don't visible for the regular table", async function () {
+            const view = getTestTableView();
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.rebuyAllowed()).toEqual(false);
+        });
+        it("rebuy button don't visible when player does not sit on table", async function () {
+            const view = getTestTableView();
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player3");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.rebuyAllowed()).toEqual(false);
+        });
+        it("rebuy button don't visible if tournament does not support rebuy", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: false,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.rebuyAllowed()).toEqual(false);
+        });
+        it("rebuy button don't visible if tournament does support rebuy, but table is not yet opened", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.opened(false);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.rebuyAllowed()).toEqual(false);
+        });
+        it("rebuy button initially visible if tournament support rebuy and player has less then max amount in the game", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+                MaximumAmountForRebuy: 1000,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(500);
+            view.myPlayer().Money(100);
+            view.tournament().addonCount(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.rebuyAllowed()).toEqual(true);
+                    return await getAccount();
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(isGetAccountCalled).toBeTruthy();
+        });
+        it("double rebuy button don't visible if player has no money to bought it", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+                RebuyFee: 1000,
+                RebuyPrice: 0,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(0);
+            view.myPlayer().Money(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.rebuyAllowed()).toEqual(true);
+                    const account = await getAccount({
+                        RealMoney: 900,
+                        GameMoney: 900,
+                    });
+                    return account;
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(isGetAccountCalled).toBeTruthy();
+            expect(tableMenuPopup.rebuyAllowed()).toEqual(false);
+        });
+        it("rebuy button visible if player has money to bought it", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+                RebuyFee: 1000,
+                RebuyPrice: 0,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(0);
+            view.myPlayer().Money(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.rebuyAllowed()).toEqual(true);
+                    return await getAccount({
+                        RealMoney: 10000,
+                        GameMoney: 10000,
+                    });
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.rebuyAllowed()).toEqual(true);
+        });
+    });
+    describe("double rebuy button", function () {
+        it("double rebuy button don't visible for the regular table", async function () {
+            const view = getTestTableView();
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.doublerebuyAllowed()).toEqual(false);
+        });
+        it("double rebuy button don't visible when player does not sit on table", async function () {
+            const view = getTestTableView();
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player3");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.doublerebuyAllowed()).toEqual(false);
+        });
+        it("double rebuy button don't visible if tournament does not support rebuy", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: false,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.doublerebuyAllowed()).toEqual(false);
+        });
+        it("double rebuy button don't visible if tournament does support rebuy, but table is not yet opened", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.opened(false);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.doublerebuyAllowed()).toEqual(false);
+        });
+        it("double rebuy button don't visible if tournament does support rebuy, but table is not yet opened", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.opened(false);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.doublerebuyAllowed()).toEqual(false);
+        });
+        it("double rebuy button initially visible if tournament support rebuy and player has 0 in game", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(0);
+            view.myPlayer().Money(0);
+            view.tournament().addonCount(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.doublerebuyAllowed()).toEqual(true);
+                    return await getAccount();
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(isGetAccountCalled).toBeTruthy();
+        });
+        it("double rebuy button don't visible if player has no money to bought it", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+                RebuyFee: 1000,
+                RebuyPrice: 0,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(0);
+            view.myPlayer().Money(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.doublerebuyAllowed()).toEqual(true);
+                    const account = await getAccount({
+                        RealMoney: 1900,
+                        GameMoney: 1900,
+                    });
+                    return account;
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(isGetAccountCalled).toBeTruthy();
+            expect(tableMenuPopup.doublerebuyAllowed()).toEqual(false);
+        });
+        it("double rebuy button visible if player has money to bought it", async function () {
+            const view = getTestTournamentTableView({
+                IsRebuyAllowed: true,
+                Options: TournamentOptionsEnum.HasRebuy,
+                RebuyFee: 1000,
+                RebuyPrice: 0,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(0);
+            view.myPlayer().Money(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.doublerebuyAllowed()).toEqual(true);
+                    return await getAccount({
+                        RealMoney: 10000,
+                        GameMoney: 10000,
+                    });
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.doublerebuyAllowed()).toEqual(true);
+        });
+    });
+    describe("addon button", function () {
+        it("addon button don't visible for the regular table", async function () {
+            const view = getTestTableView();
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.addonAllowed()).toEqual(false);
+        });
+        it("addon button don't visible when player does not sit on table", async function () {
+            const view = getTestTableView();
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player3");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.addonAllowed()).toEqual(false);
+        });
+        it("addon button don't visible if tournament does not support addon", async function () {
+            const view = getTestTournamentTableView({
+                IsAddonAllowed: false,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.addonAllowed()).toEqual(false);
+        });
+        it("addon button don't visible if tournament does support addon, but table is not yet opened", async function () {
+            const view = getTestTournamentTableView({
+                IsAddonAllowed: true,
+                Options: TournamentOptionsEnum.HasAddon,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.opened(false);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.addonAllowed()).toEqual(false);
+        });
+        it("addon button initially visible if tournament support addon", async function () {
+            const view = getTestTournamentTableView({
+                IsAddonAllowed: true,
+                Options: TournamentOptionsEnum.HasAddon,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(10000);
+            view.myPlayer().Money(10000);
+            view.tournament().addonCount(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.addonAllowed()).toEqual(true);
+                    return await getAccount();
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(isGetAccountCalled).toBeTruthy();
+        });
+        it("addon button don't visible if it was already bought", async function () {
+            const view = getTestTournamentTableView({
+                IsAddonAllowed: true,
+                Options: TournamentOptionsEnum.HasAddon,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(10000);
+            view.myPlayer().Money(10000);
+            view.tournament().addonCount(1);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            const accountManager = getAccountManager();
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.addonAllowed()).toEqual(false);
+        });
+        it("addon button don't visible if player has no money to bought it", async function () {
+            const view = getTestTournamentTableView({
+                IsAddonAllowed: true,
+                Options: TournamentOptionsEnum.HasAddon,
+                AddonFee: 1000,
+                AddonPrice: 0,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(10000);
+            view.myPlayer().Money(10000);
+            view.tournament().addonCount(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.addonAllowed()).toEqual(true);
+                    return await getAccount({
+                        RealMoney: 0,
+                        GameMoney: 0,
+                    });
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.addonAllowed()).toEqual(false);
+        });
+        it("addon button visible if player has money to bought it", async function () {
+            const view = getTestTournamentTableView({
+                IsAddonAllowed: true,
+                Options: TournamentOptionsEnum.HasAddon,
+                AddonFee: 1000,
+                AddonPrice: 0,
+            });
+            await simpleInitialization(view, 1, [400, 200]);
+            view.currentLogin("Player1");
+            view.myPlayer().TotalBet(10000);
+            view.myPlayer().Money(10000);
+            view.tournament().addonCount(0);
+            view.opened(true);
+            const currentTablePovider = {
+                currentTable: () => view,
+            };
+            const commandExecutor = {
+                executeCommand: (name, args) => {
+                    // do nothing.
+                },
+            };
+            let isGetAccountCalled = false;
+            const accountManager = {
+                getAccount: async () => {
+                    isGetAccountCalled = true;
+                    expect(tableMenuPopup.addonAllowed()).toEqual(true);
+                    return await getAccount({
+                        RealMoney: 10000,
+                        GameMoney: 10000,
+                    });
+                },
+            };
+            const tableMenuPopup = new TableMenuPopup(currentTablePovider, commandExecutor, accountManager);
+            await tableMenuPopup.shown();
+            expect(tableMenuPopup.addonAllowed()).toEqual(true);
+        });
+    });
+});

--- a/tests/popups/tablemenupopup.test.ts
+++ b/tests/popups/tablemenupopup.test.ts
@@ -1,4 +1,4 @@
-import { PersonalAccountData, TournamentOptionsEnum, Account } from "@poker/api-server";
+import { Account, PersonalAccountData, TournamentOptionsEnum } from "@poker/api-server";
 import { TableMenuPopup } from "poker/popups";
 import { IAccountManager } from "poker/services/accountManager";
 import { getTestTableView, getTestTournamentTableView, simpleInitialization } from "tests/table/helper";

--- a/tests/table/actionBlock.test.ts
+++ b/tests/table/actionBlock.test.ts
@@ -8,7 +8,7 @@ function setupTestSlider(actionBlock: ActionBlock) {
         const handleWidth = 100;
         const adj = -5;
         console.log(lineWidth - handleWidth + (-adj));
-        tableSlider.setBounds(adj, lineWidth - handleWidth + (-adj)); // -5 is base adjustment from one size; width - 5(base adj.) - 10(?)
+        tableSlider.setBounds(adj, lineWidth - handleWidth + (-adj), (relativeX) => relativeX); // -5 is base adjustment from one size; width - 5(base adj.) - 10(?)
     };
     window.onresize = x;
     x();

--- a/tests/table/helper.ts
+++ b/tests/table/helper.ts
@@ -1,4 +1,17 @@
-import { IAccount, IChat, IGame, ITournament, LobbyTournamentItem, PersonalAccountData, TournamentDefinition, TournamentPlayerStateDefinition } from "@poker/api-server";
+import {
+    IAccount,
+    IChat,
+    IGame,
+    ITournament,
+    LobbyTournamentItem,
+    PersonalAccountData,
+    Tournament,
+    TournamentDefinition,
+    TournamentOptionsEnum,
+    TournamentPlayerStateDefinition,
+    TournamentStatus,
+} from "@poker/api-server";
+import { TournamentView } from "poker/table/tournamentview";
 import { IApiProvider } from "../../js/api";
 import { GameActionsQueue } from "../../js/table/gameactionsqueue";
 import {
@@ -130,6 +143,60 @@ export const noopApiProvider: IApiProvider = {
 export function getTestTableView(): TableView {
     const tableModel = getTable();
     return new TableView(1, tableModel, noopApiProvider);
+}
+
+export const baseTournament: TournamentDefinition = {
+    TournamentId: 1,
+    TournamentName: "name",
+    Description: "desc",
+    Type: 1,
+    CurrencyId: 1,
+    PrizeCurrencyId: 1,
+    RegistrationStartDate: "",
+    RegistrationEndDate: "",
+    StartDate: "",
+    EndDate: null,
+    FinishDate: null,
+    JoinedPlayers: 0,
+    TournamentTables: [],
+    TournamentPlayers: [],
+    BetLevel: null,
+    PrizeAmount: 1000,
+    PrizeAmountType: 0,
+    CollectedPrizeAmount: 0,
+    JoinFee: 0,
+    BuyIn: 0,
+    StartingChipsAmount: 1000,
+    WellKnownBetStructure: 1,
+    WellKnownPrizeStructure: 1,
+    BlindUpdateTime: 0,
+    IsRebuyAllowed: false,
+    RebuyPrice: 100,
+    RebuyFee: null,
+    RebuyPeriodTime: 60,
+    IsAddonAllowed: false,
+    AddonPrice: 100,
+    AddonFee: null,
+    AddonPeriodTime: 60,
+    PauseTimeout: null,
+    Options: TournamentOptionsEnum.None,
+    MaximumAmountForRebuy: 1000,
+    IsRegistered: true,
+    ChipsAddedAtReBuy: 1000,
+    ChipsAddedAtDoubleReBuy: 2000,
+    Status: TournamentStatus.Started,
+    IsPaused: false,
+    MinPlayers: 2,
+    MaxPlayers: 1000,
+};
+
+export function getTestTournamentTableView(tournamentDataOverride?: Partial<TournamentDefinition>): TableView {
+    const tableModel = getTable();
+    const view = new TableView(1, tableModel, noopApiProvider);
+    const tournamentData = Object.assign({}, baseTournament, tournamentDataOverride || {});
+    const tournamentView = new TournamentView(1, tournamentData);
+    view.tournament(tournamentView);
+    return view;
 }
 
 /**

--- a/tests/table/playerCards.test.ts
+++ b/tests/table/playerCards.test.ts
@@ -4,9 +4,9 @@ import {
     loginId,
 } from "poker/authmanager";
 import { ActionBlock } from "poker/table/actionBlock";
-import { drainQueue, getTable, getTestTableView, simpleInitialization, noopApiProvider } from "./helper";
-import { TableView } from "poker/table/tableview";
 import { allBacksClassesTwoCards } from "poker/table/cardsHelper";
+import { TableView } from "poker/table/tableview";
+import { drainQueue, getTable, getTestTableView, noopApiProvider, simpleInitialization } from "./helper";
 
 const logEnabled = false;
 const log = function (message: string, ...params: any[]) {

--- a/tests/table/tableSlider.test.ts
+++ b/tests/table/tableSlider.test.ts
@@ -105,8 +105,8 @@ describe("tableSlider", function () {
             evt.originalEvent = evt;
             evt.originalEvent.gesture = {
                 center: {
-                    pageX: 150
-                }
+                    pageX: 150,
+                },
             };
             const succeed = tableSlider.selectManually(evt);
             expect(tableSlider.current()).toEqual(60);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,7 +22,8 @@
   "baseUrl": ".",
   "rootDir": ".",
   "paths": {
-    "poker/*": [ "js/*" ]
+    "poker/*": [ "js/*" ],
+    "tests/*": [ "tests/*" ]
   }
  },
  "compileOnSave": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "amd",
-    "out": "js/application.js",
+      "module": "commonjs",
+      "types": [
+          "jest"
+      ]
   },
- "compileOnSave": false,
- "exclude": [
-     "js/messages.ts",
-     "node_modules",
-     "tests"
- ]
+  "exclude": [
+      "js/messages.ts",
+      "node_modules"
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = (env) => {
             extensions: ['.js', '.jsx', '.ts', '.tsx'],
             alias: {
                 "poker": path.join(__dirname, "js"),
+                "tests": path.join(__dirname, "tests"),
             }
         },
         externals: {
@@ -37,7 +38,7 @@ module.exports = (env) => {
         },
         module: {
             rules: [
-                { test: /\.(tsx|ts)?$/, include: /js/, use: 'awesome-typescript-loader?silent=true' },
+                { test: /\.(tsx|ts)?$/, include: /js/, use: 'awesome-typescript-loader?configFileName=build-tsconfig.json&silent=true' },
                 { test: /\.css$/, use: isDevBuild ? ['style-loader', 'css-loader'] : ExtractTextPlugin.extract({ use: 'css-loader?minimize' }) },
                 { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' }
             ]


### PR DESCRIPTION
Whole purpose of this refactoring is to be able create tests for the addon/rebuy buttons on the table popup menu.
Idea behind refactoring is following: Instead of relying on the global objects, depends on the interfaces for abstracting implementation. Actual implementation passed to the tested object by the caller. In the runtime this is other code in the library, in the tests this is preconfigured objects.