### PR TITLE
Change how authManager exported

### DIFF
--- a/js/app.ts
+++ b/js/app.ts
@@ -1,11 +1,11 @@
 import { getAuthToken, setAuthToken } from "@poker/api-server";
 import * as $ from "jquery";
+import { authManager } from "poker/authmanager";
 import { CommandManager } from "poker/commandmanager";
 import { AccountManager } from "poker/services/accountManager";
 import { TableView } from "poker/table/tableview";
 import "signalr";
 import * as signals from "signals";
-import * as authManager from "./authmanager";
 import { debugSettings } from "./debugsettings";
 import { _ } from "./languagemanager";
 import * as metadataManager from "./metadatamanager";

--- a/js/authmanager.ts
+++ b/js/authmanager.ts
@@ -6,7 +6,7 @@ import ko = require("knockout");
 import { appConfig } from "./appconfig";
 import { settings } from "./settings";
 
-class AuthManager {
+export class AuthManager {
     public authenticated: KnockoutObservable<boolean>;
     public login: KnockoutObservable<string>;
     public loginId: KnockoutObservable<number>;
@@ -89,5 +89,4 @@ class AuthManager {
     }
 }
 
-const authManager: AuthManager = new AuthManager();
-export = authManager;
+export const authManager: AuthManager = new AuthManager();

--- a/js/pages/accountpage.ts
+++ b/js/pages/accountpage.ts
@@ -1,7 +1,7 @@
 import * as ko from "knockout";
 import { appConfig } from "poker/appconfig";
+import { authManager } from "poker/authmanager";
 import { App } from "../app";
-import * as authManager from "../authmanager";
 import { AccountManager } from "../services/accountManager";
 import { settings } from "../settings";
 import { PageBase } from "../ui/pagebase";

--- a/js/pages/cashierpage.ts
+++ b/js/pages/cashierpage.ts
@@ -1,6 +1,6 @@
 import * as ko from "knockout";
+import { authManager } from "poker/authmanager";
 import { App } from "../app";
-import * as authManager from "../authmanager";
 import { accountService, reloadManager, WebsiteService } from "../services";
 import { PageBase } from "../ui/pagebase";
 

--- a/js/pages/homepage.ts
+++ b/js/pages/homepage.ts
@@ -1,9 +1,9 @@
 declare var host: string;
 
 import { Information } from "@poker/api-server";
+import { authManager } from "poker/authmanager";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 import { debugSettings } from "../debugsettings";
 import { _ } from "../languagemanager";
 import * as metadataManager from "../metadatamanager";

--- a/js/pages/lobbypage.ts
+++ b/js/pages/lobbypage.ts
@@ -4,7 +4,7 @@ declare var host: string;
 import { Game, LobbyTournamentItem, Tournament, TournamentDefinition } from "@poker/api-server";
 import * as ko from "knockout";
 import * as moment from "moment";
-import * as authManager from "poker/authmanager";
+import { authManager } from "poker/authmanager";
 import { AccountManager } from "poker/services/accountManager";
 import { settings } from "poker/settings";
 import { App } from "../app";

--- a/js/pages/tournamentlobbypage.ts
+++ b/js/pages/tournamentlobbypage.ts
@@ -13,9 +13,9 @@ import {
 } from "@poker/api-server";
 import * as ko from "knockout";
 import * as moment from "moment";
+import { authManager } from "poker/authmanager";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 import { debugSettings } from "../debugsettings";
 import { _ } from "../languagemanager";
 import * as metadataManager from "../metadatamanager";

--- a/js/pages/withdrawalpage.ts
+++ b/js/pages/withdrawalpage.ts
@@ -1,5 +1,5 @@
+import { authManager } from "poker/authmanager";
 import { App } from "../app";
-import * as authManager from "../authmanager";
 import { PageBlock } from "../pageblock";
 import { AccountManager } from "../services/accountManager";
 import { PageBase } from "../ui/pagebase";

--- a/js/popups/accountstatuspopup.ts
+++ b/js/popups/accountstatuspopup.ts
@@ -1,8 +1,8 @@
 /// <reference path="../poker.commanding.api.ts" />
 
 import * as ko from "knockout";
+import { authManager } from "poker/authmanager";
 import { App } from "../app";
-import * as authManager from "../authmanager";
 import { _ } from "../languagemanager";
 import { accountService } from "../services";
 import { PopupBase } from "../ui/popupbase";

--- a/js/popups/authpopup.ts
+++ b/js/popups/authpopup.ts
@@ -1,7 +1,7 @@
 ﻿import * as ko from "knockout";
+import { authManager } from "poker/authmanager";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 import { _ } from "../languagemanager";
 import { keyboardActivationService } from "../services";
 import { settings } from "../settings";

--- a/js/popups/morepopup.ts
+++ b/js/popups/morepopup.ts
@@ -1,9 +1,9 @@
 ﻿import { Message } from "@poker/api-server";
 import * as ko from "knockout";
 import { appConfig } from "poker/appconfig";
+import { authManager } from "poker/authmanager";
 import { _ } from "poker/languagemanager";
 import { App } from "../app";
-import * as authManager from "../authmanager";
 import { WebsiteService } from "../services";
 import { AccountManager } from "../services/accountManager";
 import { settings } from "../settings";

--- a/js/popups/registrationpopup.ts
+++ b/js/popups/registrationpopup.ts
@@ -1,7 +1,7 @@
 import * as ko from "knockout";
+import { authManager } from "poker/authmanager";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 import { _ } from "../languagemanager";
 import * as metadataManager from "../metadatamanager";
 import { AccountManager } from "../services/accountManager";

--- a/js/popups/tablemenupopup.ts
+++ b/js/popups/tablemenupopup.ts
@@ -1,12 +1,12 @@
 /* tslint:disable:no-bitwise */
 import { PersonalAccountData, TournamentOptionsEnum } from "@poker/api-server";
 import * as ko from "knockout";
+import { authManager } from "poker/authmanager";
 import { ICommandExecutor } from "poker/commandmanager";
 import { ICurrentTableProvider } from "poker/services";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
-import { AccountManager, IAccountManager } from "../services/accountManager";
+import { IAccountManager } from "../services/accountManager";
 import { settings } from "../settings";
 import { tableManager } from "../table/tablemanager";
 import { TournamentView } from "../table/tournamentview";

--- a/js/services/accountservice.ts
+++ b/js/services/accountservice.ts
@@ -1,4 +1,4 @@
-import * as authManager from "../authmanager";
+import { authManager } from "poker/authmanager";
 import { AccountManager } from "./accountManager";
 
 export class AccountService {

--- a/js/services/appreloadservice.ts
+++ b/js/services/appreloadservice.ts
@@ -1,6 +1,6 @@
 ﻿import { TableReload } from "@poker/api-server";
+import { authManager } from "poker/authmanager";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 
 declare var host: string;
 

--- a/js/table/actionBlock.ts
+++ b/js/table/actionBlock.ts
@@ -2,10 +2,10 @@
 
 import { Game } from "@poker/api-server";
 import * as ko from "knockout";
+import { authManager } from "poker/authmanager";
 import * as signals from "signals";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 import { debugSettings } from "../debugsettings";
 import { withCommas } from "../helpers";
 import { _ } from "../languagemanager";

--- a/js/table/playerMessage.ts
+++ b/js/table/playerMessage.ts
@@ -1,5 +1,5 @@
 import * as ko from "knockout";
-import * as authManager from "../authmanager";
+import { authManager } from "poker/authmanager";
 
 export class PlayerMessage {
     public messageId: number;

--- a/js/table/tablemanager.ts
+++ b/js/table/tablemanager.ts
@@ -7,11 +7,11 @@ import {
 } from "@poker/api-server";
 import * as ko from "knockout";
 import { DefaultApiProvider, IApiProvider } from "poker/api";
+import { authManager } from "poker/authmanager";
 import { ICommandManager } from "poker/commandmanager";
 import { TablePlaceModel } from "poker/table/tabpleplacemodel";
 import * as signals from "signals";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 import { debugSettings } from "../debugsettings";
 import { _ } from "../languagemanager";
 import { SimplePopup } from "../popups/simplepopup";

--- a/js/table/tableview.ts
+++ b/js/table/tableview.ts
@@ -2,10 +2,10 @@
 import * as ko from "knockout";
 import * as moment from "moment";
 import { IApiProvider } from "poker/api";
+import { authManager } from "poker/authmanager";
 import * as signals from "signals";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 import { debugSettings } from "../debugsettings";
 import { withCommas } from "../helpers";
 import { _ } from "../languagemanager";

--- a/js/table/tournamentview.ts
+++ b/js/table/tournamentview.ts
@@ -1,9 +1,9 @@
 ﻿import { Game, Tournament, TournamentDefinition, TournamentPlayerStatus, TournamentPrizeStructure, TournamentStatus } from "@poker/api-server";
 import * as ko from "knockout";
+import { authManager } from "poker/authmanager";
 import { TableView } from "poker/table/tableview";
 import { App } from "../app";
 import { appConfig } from "../appconfig";
-import * as authManager from "../authmanager";
 import { debugSettings } from "../debugsettings";
 import { _ } from "../languagemanager";
 import * as metadataManager from "../metadatamanager";

--- a/tests/gameplay/players2.test.ts
+++ b/tests/gameplay/players2.test.ts
@@ -1,8 +1,5 @@
 import * as ko from "knockout";
-import {
-    login,
-    loginId,
-} from "../../js/authmanager";
+import { authManager } from "poker/authmanager";
 import { debugSettings } from "../../js/debugsettings";
 import { ActionBlock } from "../../js/table/actionBlock";
 import { GameActionsQueue } from "../../js/table/gameactionsqueue";
@@ -10,6 +7,9 @@ import {
     TableView,
 } from "../../js/table/tableview";
 import { drainQueue, getTable, getTestTableView, printTableView, simpleInitialization } from "../table/helper";
+
+const login = authManager.login;
+const loginId = authManager.loginId;
 
 describe("gameplay", function () {
     const login1 = "Player1";

--- a/tests/gameplay/players3.test.ts
+++ b/tests/gameplay/players3.test.ts
@@ -1,14 +1,14 @@
 import * as ko from "knockout";
-import {
-    login,
-    loginId,
-} from "../../js/authmanager";
+import { authManager } from "poker/authmanager";
 import { debugSettings } from "../../js/debugsettings";
 import { GameActionsQueue } from "../../js/table/gameactionsqueue";
 import {
     TableView,
 } from "../../js/table/tableview";
 import { drainQueue, getTable, getTestTableView, printTableView, simpleInitialization } from "../table/helper";
+
+const login = authManager.login;
+const loginId = authManager.loginId;
 
 describe("gameplay", function () {
     const login1 = "Player1";

--- a/tests/gameplay/waitbb.test.ts
+++ b/tests/gameplay/waitbb.test.ts
@@ -1,8 +1,5 @@
 import * as ko from "knockout";
-import {
-    login,
-    loginId,
-} from "../../js/authmanager";
+import { authManager } from "poker/authmanager";
 import { debugSettings } from "../../js/debugsettings";
 import { ActionBlock } from "../../js/table/actionBlock";
 import { GameActionsQueue } from "../../js/table/gameactionsqueue";
@@ -10,6 +7,9 @@ import {
     TableView,
 } from "../../js/table/tableview";
 import { drainQueue, getTable, getTestTableView, printTableView, simpleInitialization } from "../table/helper";
+
+const login = authManager.login;
+const loginId = authManager.loginId;
 
 describe("gameplay", function () {
     const login1 = "Player1";

--- a/tests/pages/tournamentlobbypage.test.ts
+++ b/tests/pages/tournamentlobbypage.test.ts
@@ -4,7 +4,7 @@ import {
     TournamentPlayerStatus,
     TournamentStatus,
 } from "@poker/api-server";
-import * as authManager from "poker/authmanager";
+import { authManager } from "poker/authmanager";
 import * as metadataManager from "poker/metadatamanager";
 import { TournamentLobbyPage } from "poker/pages/tournamentlobbypage";
 

--- a/tests/panel1/autoButtons.test.ts
+++ b/tests/panel1/autoButtons.test.ts
@@ -1,8 +1,4 @@
 import * as ko from "knockout";
-import {
-    login,
-    loginId,
-} from "../../js/authmanager";
 import { debugSettings } from "../../js/debugsettings";
 import { ActionBlock } from "../../js/table/actionBlock";
 import { GameActionsQueue } from "../../js/table/gameactionsqueue";

--- a/tests/panel1/mainbuttons.test.ts
+++ b/tests/panel1/mainbuttons.test.ts
@@ -1,8 +1,4 @@
 import * as ko from "knockout";
-import {
-    login,
-    loginId,
-} from "../../js/authmanager";
 import { debugSettings } from "../../js/debugsettings";
 import { ActionBlock } from "../../js/table/actionBlock";
 import { GameActionsQueue } from "../../js/table/gameactionsqueue";

--- a/tests/panel1/quickbuttons.test.ts
+++ b/tests/panel1/quickbuttons.test.ts
@@ -1,8 +1,5 @@
 import * as ko from "knockout";
-import {
-    login,
-    loginId,
-} from "../../js/authmanager";
+import { authManager } from "poker/authmanager";
 import { debugSettings } from "../../js/debugsettings";
 import { ActionBlock } from "../../js/table/actionBlock";
 import { GameActionsQueue } from "../../js/table/gameactionsqueue";
@@ -10,6 +7,9 @@ import {
     TableView,
 } from "../../js/table/tableview";
 import { drainQueue, getTable, getTestTableView, printTableView, simpleInitialization } from "../table/helper";
+
+const login = authManager.login;
+const loginId = authManager.loginId;
 
 describe("quick buttons", function () {
     GameActionsQueue.waitDisabled = true;

--- a/tests/table/duplicateConnection.test.ts
+++ b/tests/table/duplicateConnection.test.ts
@@ -2,10 +2,6 @@ import * as ko from "knockout";
 import { DefaultApiProvider } from "poker/api";
 import { CommandManager } from "poker/commandmanager";
 import { App } from "../../js/app";
-import {
-    login,
-    loginId,
-} from "../../js/authmanager";
 import { debugSettings } from "../../js/debugsettings";
 import { slowInternetService } from "../../js/services";
 import { ActionBlock } from "../../js/table/actionBlock";

--- a/tests/table/playerCards.test.ts
+++ b/tests/table/playerCards.test.ts
@@ -1,8 +1,5 @@
 import { appConfig, overrideConfiguration } from "poker/appconfig";
-import {
-    login,
-    loginId,
-} from "poker/authmanager";
+import { authManager } from "poker/authmanager";
 import { debugSettings } from "poker/debugsettings";
 import { ActionBlock } from "poker/table/actionBlock";
 import { allBacksClassesTwoCards } from "poker/table/cardsHelper";
@@ -15,6 +12,9 @@ const log = function (message: string, ...params: any[]) {
         console.log(message);
     }
 };
+
+const login = authManager.login;
+const loginId = authManager.loginId;
 
 async function playUntilFlop(playerId: number) {
     const tableModel = getTable();

--- a/tests/table/tableView.test.ts
+++ b/tests/table/tableView.test.ts
@@ -1,9 +1,6 @@
 /** global process */
 import * as ko from "knockout";
-import {
-    login,
-    loginId,
-} from "../../js/authmanager";
+import { authManager } from "poker/authmanager";
 import { debugSettings } from "../../js/debugsettings";
 import { allBacksClassesFourCards } from "../../js/table/cardsHelper";
 import { GameActionsQueue } from "../../js/table/gameactionsqueue";
@@ -26,6 +23,9 @@ function getSeatPlayer(seat: number, initialAmount: number): PlayerStatusInfo {
         Status: 0,
     };
 }
+
+const login = authManager.login;
+const loginId = authManager.loginId;
 
 describe("Table view", () => {
     describe("No limit", () => {


### PR DESCRIPTION
Seaprately export AuthManager class, as partial way to make
code testable. Subsequent work should reduce usage of global
value authManager and instead of that, operate with AuthManager
over interface