### PR TITLE
Add tests for lobby page configuration

### DIFF
--- a/js/pages/lobbypage.ts
+++ b/js/pages/lobbypage.ts
@@ -8,7 +8,7 @@ import { authManager } from "poker/authmanager";
 import { AccountManager } from "poker/services/accountManager";
 import { settings } from "poker/settings";
 import { App } from "../app";
-import { appConfig } from "../appconfig";
+import { AppConfig } from "../appconfig";
 import { debugSettings } from "../debugsettings";
 import { _ } from "../languagemanager";
 import * as metadataManager from "../metadatamanager";
@@ -160,7 +160,7 @@ export class LobbyPage extends PageBase {
     public tournamentTablesEnabled: KnockoutObservable<boolean>;
     public sngTablesEnabled: KnockoutObservable<boolean>;
 
-    constructor() {
+    constructor(private appConfig: AppConfig) {
         super();
         const self = this;
 
@@ -201,7 +201,9 @@ export class LobbyPage extends PageBase {
             this.sngTablesEnabled(false);
         }
 
-        if (appConfig.tournament.enableTournamentOnly) {
+        if (appConfig.tournament.enableTournamentOnly && appConfig.tournament.enabled) {
+            this.cashTablesEnabled(false);
+            this.sngTablesEnabled(false);
             this.slider.enabled(false);
             this.slider.currentIndex(1);
         }
@@ -326,7 +328,7 @@ export class LobbyPage extends PageBase {
         const betLevels = options.bets();
         const moneyType = options.currency();
         const limitType = options.limits();
-        const data = await gameApi.getTables(fullTables, privateTables, maxPlayers, betLevels, moneyType, limitType, appConfig.game.showTournamentTables);
+        const data = await gameApi.getTables(fullTables, privateTables, maxPlayers, betLevels, moneyType, limitType, this.appConfig.game.showTournamentTables);
         if (!this.visible()) {
             return;
         }
@@ -338,11 +340,11 @@ export class LobbyPage extends PageBase {
                 item.IsOpened = tableManager.isOpened(item.TableId);
             });
             this.tables(tables);
-            if (appConfig.auth.automaticTableSelection && tables.length === 1) {
+            if (this.appConfig.auth.automaticTableSelection && tables.length === 1) {
                 this.selectTable(tables[0]);
             }
 
-            if (appConfig.game.seatMode || appConfig.game.tablePreviewMode) {
+            if (this.appConfig.game.seatMode || this.appConfig.game.tablePreviewMode) {
                 const tableIdString = localStorage.getItem("tableId");
                 if (tableIdString !== null) {
                     const tableIdInt = parseInt(tableIdString, 10);
@@ -396,19 +398,19 @@ export class LobbyPage extends PageBase {
             authenticated: false,
             wasAuthenticated: false,
         };
-        const authResult = appConfig.lobby.openTableRequireAuthentication
-            ? appConfig.auth.allowGuest ? await app.requireGuestAuthentication() : await app.requireAuthentication()
+        const authResult = this.appConfig.lobby.openTableRequireAuthentication
+            ? this.appConfig.auth.allowGuest ? await app.requireGuestAuthentication() : await app.requireAuthentication()
             : notAuthenticatedResult;
         if (authResult.authenticated) {
             app.executeCommand("app.selectTable", [table, authResult.wasAuthenticated]);
 
-            if (appConfig.game.seatMode || appConfig.game.tablePreviewMode) {
+            if (this.appConfig.game.seatMode || this.appConfig.game.tablePreviewMode) {
                 const tableId = table.TableId.toString();
                 console.log("Save table id " + tableId + " for future auto select of this table.");
                 localStorage.setItem("tableId", tableId);
             }
 
-            if (appConfig.game.seatMode) {
+            if (this.appConfig.game.seatMode) {
                 app.executeCommand("page.seats");
             } else {
                 app.executeCommand("page.tables");

--- a/js/pages/lobbypageblock.ts
+++ b/js/pages/lobbypageblock.ts
@@ -1,4 +1,5 @@
 ﻿import { TournamentDefinition } from "@poker/api-server";
+import { appConfig } from "poker/appconfig";
 import { authManager } from "poker/authmanager";
 import { UIManager } from "poker/services/uimanager";
 import { App } from "../app";
@@ -18,7 +19,7 @@ export class LobbyPageBlock extends PageBlock {
     public tablesListPage: TablesListPage;
 
     constructor() {
-        const lobbyPage = new LobbyPage();
+        const lobbyPage = new LobbyPage(appConfig);
         UIManager.addTabBarItemMapping("lobby", "tablesFilter");
         UIManager.addTabBarItemMapping("lobby", "tournamentsFilter");
         UIManager.addTabBarItemMapping("lobby", "sngFilter");

--- a/tests/pages/lobbyconfiguration.test.ts
+++ b/tests/pages/lobbyconfiguration.test.ts
@@ -1,0 +1,57 @@
+import { LobbyPage } from "poker/pages";
+
+describe("Lobby page cofiguration", function () {
+    global.messages = {
+    };
+    it("All tables should be enabled", function () {
+        const testAppConfig: any = {
+            lobby: {
+                cashTablesEnabled: true,
+                sngTablesEnabled: true,
+                tournamentTablesEnabled: true,
+            },
+            tournament: {
+                enabled: true,
+                enableTournamentOnly: false,
+            },
+        };
+        const lobbyPage = new LobbyPage(testAppConfig);
+        expect(lobbyPage.cashTablesEnabled()).toBeTruthy();
+        expect(lobbyPage.sngTablesEnabled()).toBeTruthy();
+        expect(lobbyPage.tournamentTablesEnabled()).toBeTruthy();
+    });
+    it("Only cash tables should be enabled, if tournament in general is disabled", function () {
+        const testAppConfig: any = {
+            lobby: {
+                cashTablesEnabled: true,
+                sngTablesEnabled: true,
+                tournamentTablesEnabled: true,
+            },
+            tournament: {
+                enabled: false,
+                enableTournamentOnly: true,
+            },
+        };
+        const lobbyPage = new LobbyPage(testAppConfig);
+        expect(lobbyPage.cashTablesEnabled()).toBeTruthy();
+        expect(lobbyPage.sngTablesEnabled()).not.toBeTruthy();
+        expect(lobbyPage.tournamentTablesEnabled()).not.toBeTruthy();
+    });
+    it("Only tournament tables should be enabled, if tournamentonly config is turned on", function () {
+        const testAppConfig: any = {
+            lobby: {
+                cashTablesEnabled: true,
+                sngTablesEnabled: true,
+                tournamentTablesEnabled: true,
+            },
+            tournament: {
+                enabled: true,
+                enableTournamentOnly: true,
+            },
+        };
+        const lobbyPage = new LobbyPage(testAppConfig);
+        expect(lobbyPage.cashTablesEnabled()).not.toBeTruthy();
+        expect(lobbyPage.sngTablesEnabled()).not.toBeTruthy();
+        expect(lobbyPage.tournamentTablesEnabled()).toBeTruthy();
+    });
+});


### PR DESCRIPTION
#176 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved lobby table type availability logic to ensure correct enabling or disabling of cash, SNG, and tournament tables based on configuration settings.
- **Tests**
	- Added tests to verify that table type availability in the lobby reflects different configuration scenarios accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->