### PR TITLE
Expose API which is required for testing

### DIFF
--- a/js/appInit.ts
+++ b/js/appInit.ts
@@ -37,7 +37,7 @@ function configureBindings() {
     }
 }
 
-export function bootstrap(localConfiguration?: Partial<AppConfig>) {
+function bootstrap(localConfiguration?: Partial<AppConfig>) {
     overrideConfiguration(localConfiguration || {});
 
     // tslint:disable:no-string-literal
@@ -135,4 +135,9 @@ export function bootstrap(localConfiguration?: Partial<AppConfig>) {
     }
 }
 
-// bootstrap();
+export = {
+    bootstrap,
+    registerBindings,
+    registerComponents,
+    registerExtenders,
+};


### PR DESCRIPTION
Exposed functions could be used to initialize KO binding and components in the test suite.