### PR TITLE
Allow override tablet animation settings separately

### DIFF
--- a/js/appInit.ts
+++ b/js/appInit.ts
@@ -74,9 +74,9 @@ export function registerTableView() {
     window["ActionBlock"] = ActionBlock;
 }
 
-export function bootstrap(localConfiguration?: Partial<AppConfig>, animationSettingsOverride?: Partial<AnimationSettings>) {
+export function bootstrap(localConfiguration?: Partial<AppConfig>, animationSettingsOverride?: Partial<AnimationSettings>, tabletAnimationSettingsOverride?: Partial<AnimationSettings>) {
     overrideConfiguration(localConfiguration || {});
-    AnimationSettings.setOverride(animationSettingsOverride || {});
+    AnimationSettings.setOverride(animationSettingsOverride || {}, tabletAnimationSettingsOverride || {});
 
     // tslint:disable:no-string-literal
     window["ko"] = ko;

--- a/js/table/animationsettings.ts
+++ b/js/table/animationsettings.ts
@@ -4,8 +4,9 @@ export class AnimationSettings {
 
     public static platform = "default";
 
-    public static setOverride(configuration: Partial<AnimationSettings>): void {
+    public static setOverride(configuration: Partial<AnimationSettings>, tabletConfiguration: Partial<AnimationSettings>): void {
         AnimationSettings.configurationOverride = configuration;
+        AnimationSettings.tabletConfigurationOverride = tabletConfiguration;
     }
 
     public static getSettings(): AnimationSettings {
@@ -16,6 +17,9 @@ export class AnimationSettings {
                 break;
             case "tablet":
                 settings = AnimationSettings.tabletSettings();
+                if (AnimationSettings.tabletConfigurationOverride) {
+                    settings = mergeDeep(settings, AnimationSettings.tabletConfigurationOverride);
+                }
                 break;
             default:
                 settings = AnimationSettings.defaultSettings();
@@ -40,11 +44,12 @@ export class AnimationSettings {
 
     public static tabletSettings() {
         const settings = new AnimationSettings();
-        settings.dealCardsTime = 500;
+        settings.dealCardsTime = 1500;
         return settings;
     }
 
     private static configurationOverride?: Partial<AnimationSettings>;
+    private static tabletConfigurationOverride?: Partial<AnimationSettings>;
 
     public dealCardsTime: number = 300;
     public finishGamePrePause: number = 100;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separate animation settings specifically for tablet devices, allowing for more tailored user experiences on different platforms.

* **Enhancements**
  * Increased the default card dealing animation time on tablets for smoother visual effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->