### PR TITLE
Use Pointer Events API instead of deprecated Touch Events

### DIFF
--- a/js/app.ts
+++ b/js/app.ts
@@ -1154,11 +1154,11 @@ export class App {
         $("body").on("keyup", "input", function(event) {
             $(this).trigger("change");
         });
-        $("body").on("touchstart", ".button, .actionable", function(event) {
+        $("body").on("pointerdown", ".button, .actionable", function(event) {
             $(this).addClass("pressed");
-        }).on("touchend", ".button, .actionable", function(event) {
+        }).on("pointerup", ".button, .actionable", function(event) {
             $(this).removeClass("pressed");
-        }).on("touchcancel", ".button, .actionable", function(event) {
+        }).on("pointercancel", ".button, .actionable", function(event) {
             $(this).removeClass("pressed");
         });
     }

--- a/js/bindings.ts
+++ b/js/bindings.ts
@@ -300,7 +300,7 @@ export function registerBindings() {
                 wrapperValueAccessor = function(): any {
                     if (isFast) {
                         return {
-                            touchstart: handler,
+                            pointerdown: handler,
                         };
                     }
 
@@ -660,7 +660,7 @@ export function registerBindings() {
                     currentTargetElement.focus();
                 }, 0);
             };
-            ko.bindingHandlers.event.init(element, function() { return { touchstart: handler }; },
+            ko.bindingHandlers.event.init(element, function() { return { pointerdown: handler }; },
                 allBindings, viewModel, bindingContext);
         },
     };

--- a/js/services/soundmanager.ts
+++ b/js/services/soundmanager.ts
@@ -211,18 +211,18 @@ export class SoundManager {
             }
             /* tslint:enable:no-string-literal */
 
-            if (context.state === "suspended" && "ontouchstart" in window) {
+            if (context.state === "suspended" && "pointerdown" in window) {
                 const unlock = function () {
                     context.resume().then(function () {
-                        document.body.removeEventListener("touchstart", unlock);
-                        document.body.removeEventListener("touchend", unlock);
+                        document.body.removeEventListener("pointerdown", unlock);
+                        document.body.removeEventListener("pointerup", unlock);
 
                         resolve(true);
                     }, reject);
                 };
 
-                document.body.addEventListener("touchstart", unlock, false);
-                document.body.addEventListener("touchend", unlock, false);
+                document.body.addEventListener("pointerdown", unlock, false);
+                document.body.addEventListener("pointerup", unlock, false);
             } else {
                 resolve(false);
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated touch event handling throughout the app to use pointer events instead, improving compatibility across devices.
  * Adjusted audio context unlocking to respond to pointer events for more reliable audio playback activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->