### PR TITLE
Don't display overlay

### DIFF
--- a/js/pages/homepage.ts
+++ b/js/pages/homepage.ts
@@ -52,7 +52,7 @@ export class HomePage extends PageBase {
             }
 
             if (appConfig.game.seatMode) {
-                return !!settings.login();
+                return !!settings.login()?.trim();
             }
 
             return false;

--- a/js/pages/homepage.ts
+++ b/js/pages/homepage.ts
@@ -46,13 +46,13 @@ export class HomePage extends PageBase {
 
     constructor() {
         super();
-        this.showScreenOverlay = ko.computed(() => {
+        this.showScreenOverlay = ko.pureComputed(() => {
             if (!appConfig.ui.enableScreenOverlay) {
                 return false;
             }
 
-            if (document.body.classList.contains("poker-feature-single-seat")) {
-                return settings.login() !== "";
+            if (appConfig.game.seatMode) {
+                return !!settings.login();
             }
 
             return false;

--- a/tests/pages/homepage.test.ts
+++ b/tests/pages/homepage.test.ts
@@ -13,15 +13,18 @@ describe("Home page", function () {
     describe("Screen overlay", function () {
         let enableScreenOverlay: boolean;
         let seatMode: boolean;
+        let originalLogin: string | null | undefined;
         beforeEach(() => {
             enableScreenOverlay = appConfig.ui.enableScreenOverlay;
             seatMode = appConfig.game.seatMode;
+            originalLogin = settings.login();
             appConfig.ui.enableScreenOverlay = true;
             appConfig.game.seatMode = true;
         });
         afterEach(() => {
             appConfig.ui.enableScreenOverlay = enableScreenOverlay;
             appConfig.game.seatMode = seatMode;
+            settings.login(originalLogin as any);
         });
         it("if screen overlay is disabled, do not show screen overlay", function () {
             appConfig.ui.enableScreenOverlay = false;

--- a/tests/pages/homepage.test.ts
+++ b/tests/pages/homepage.test.ts
@@ -1,0 +1,57 @@
+import { appConfig } from "poker/appconfig";
+import { authManager } from "poker/authmanager";
+import * as metadataManager from "poker/metadatamanager";
+import { HomePage } from "poker/pages/homepage";
+import { settings } from "poker/settings";
+import { Authenticated, notAuthenticated } from "tests/authHelper";
+
+describe("Home page", function () {
+    beforeAll(() => {
+        global.messages = {
+        };
+    });
+    describe("Screen overlay", function () {
+        let enableScreenOverlay: boolean;
+        let seatMode: boolean;
+        beforeEach(() => {
+            enableScreenOverlay = appConfig.ui.enableScreenOverlay;
+            seatMode = appConfig.game.seatMode;
+            appConfig.ui.enableScreenOverlay = true;
+            appConfig.game.seatMode = true;
+        });
+        afterEach(() => {
+            appConfig.ui.enableScreenOverlay = enableScreenOverlay;
+            appConfig.game.seatMode = seatMode;
+        });
+        it("if screen overlay is disabled, do not show screen overlay", function () {
+            appConfig.ui.enableScreenOverlay = false;
+            const homePage = new HomePage();
+            expect(homePage.showScreenOverlay()).toEqual(false);
+        });
+        
+        it("if no login specified (undefined) in the configuration, allow enter login password", function () {
+            settings.login(undefined);
+            const homePage = new HomePage();
+
+            expect(homePage.showScreenOverlay()).toEqual(false);
+        });
+        it("if no login specified (null) in the configuration, allow enter login password", function () {
+            settings.login(null);
+            const homePage = new HomePage();
+
+            expect(homePage.showScreenOverlay()).toEqual(false);
+        });
+        it("if no login specified ('') in the configuration, allow enter login password", function () {
+            settings.login("");
+            const homePage = new HomePage();
+
+            expect(homePage.showScreenOverlay()).toEqual(false);
+        });
+        it("if login specified in the configuration, enable screen overlay", function () {
+            settings.login("user");
+            const homePage = new HomePage();
+
+            expect(homePage.showScreenOverlay()).toEqual(true);
+        });
+    });
+});

--- a/tests/pages/homepage.test.ts
+++ b/tests/pages/homepage.test.ts
@@ -50,6 +50,12 @@ describe("Home page", function () {
 
             expect(homePage.showScreenOverlay()).toEqual(false);
         });
+        it("if no login specified ('  ') in the configuration, allow enter login password", function () {
+            settings.login("  ");
+            const homePage = new HomePage();
+
+            expect(homePage.showScreenOverlay()).toEqual(false);
+        });
         it("if login specified in the configuration, enable screen overlay", function () {
             settings.login("user");
             const homePage = new HomePage();


### PR DESCRIPTION
when no login present in the settings

## Summary

* **Bug Fixes**
  * Improved the logic for displaying the screen overlay on the homepage, ensuring it responds correctly to configuration settings and user login status.

* **Tests**
  * Added new tests to verify the correct behavior of the screen overlay feature under various configuration and login scenarios.
