### PR TITLE
Allow set default language via configuration

### DIFF
--- a/js/languagemanager.ts
+++ b/js/languagemanager.ts
@@ -1,4 +1,5 @@
 import { observable, Observable } from "knockout";
+import { appConfig } from "poker/appconfig"
 
 declare let messages: any;
 
@@ -8,10 +9,10 @@ export interface LanguageDescriptor {
 }
 
 export class LanguageManager {
-    public currentLang: Observable<string> = observable("ru");
+    public currentLang: Observable<string> = observable("en");
 
     constructor() {
-        const lang = localStorage.getItem("lang") || "ru";
+        const lang = localStorage.getItem("lang") || (appConfig.ui.defaultUILanguage || "en");
         this.currentLang(lang);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now automatically sets the default language based on your saved preferences or external configuration, defaulting to English if none is specified.

* **Refactor**
  * Improved handling of default language selection for a more dynamic and user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->