### PR TITLE
Always play increase bet sounds on seat

### DIFF
--- a/js/services/soundmanager.ts
+++ b/js/services/soundmanager.ts
@@ -173,11 +173,10 @@ export class SoundManager {
         }
     }
     public playIncreaseBetOrRaise() {
-        if (!this.enabled() || !this.tableSoundsEnabled()) {
-            return;
-        }
-
-        this.quickPlay(`${this.basePath}/${this.variant}/bet.mp3`);
+        // if (!this.enabled() || !this.tableSoundsEnabled()) {
+        //     return;
+        // }
+        this.quickPlay(`${this.basePath}/${this.variant}/money.mp3`);
     }
     private quickPlay(fileName: string) {
         /* tslint:disable:no-string-literal */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated bet/raise audio to a new money sound effect for clearer feedback.
  * The bet/raise sound now plays consistently on every increase, independent of table sound settings, providing immediate audible confirmation of your action.
  * No configuration changes are needed; existing preferences remain unchanged outside of this specific sound.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->