### PR TITLE
Dont' produce error if no game was on table

### DIFF
--- a/js/popups/handhistorypopup.ts
+++ b/js/popups/handhistorypopup.ts
@@ -60,13 +60,15 @@ export class HandHistoryPopup extends PopupBase {
         this.showHistoryModeSelector(handHistoryConfig.showPictureHistory && handHistoryConfig.showTextHistory);
         const view = this.tableView();
         const lastHand = view.lastHandHistory();
-        this.has2Cards = ko.observable<boolean>(lastHand.gameType() === 1 ? true : false);
-        this.has4Cards = ko.observable<boolean>(lastHand.gameType() === 1 ? false : true);
-        this.detailedOperations(lastHand.detailedOperations());
-        this.shortOperations(lastHand.shortOperations());
-        this.cards(lastHand.cards());
-        this.lastHandTitle(_("handhistory.caption", { handId: lastHand.id }));
-        this.playersData(lastHand.playersData());
+        if (lastHand) {
+            this.has2Cards = ko.observable<boolean>(lastHand.gameType() === 1 ? true : false);
+            this.has4Cards = ko.observable<boolean>(lastHand.gameType() === 1 ? false : true);
+            this.detailedOperations(lastHand.detailedOperations());
+            this.shortOperations(lastHand.shortOperations());
+            this.cards(lastHand.cards());
+            this.lastHandTitle(_("handhistory.caption", { handId: lastHand.id }));
+            this.playersData(lastHand.playersData());
+        }
         GameActionsQueue.waitDisabled = true;
         app.tablesPage.tablesShown(false);
         app.popupClosed.addOnce(function (popupName: string) {

--- a/js/table/tableview.ts
+++ b/js/table/tableview.ts
@@ -205,7 +205,7 @@ export class TableView {
     public onMyTurn: Signal;
     public onGamefinished: Signal;
     public tablePlaces: TablePlaces;
-    public lastHandHistory: ko.Observable<HandHistory>;
+    public lastHandHistory: ko.Observable<HandHistory | null> = ko.observable<HandHistory | null>(null);
     public hasPreviousHand: ko.Computed<boolean>;
     public tableBetsCaption: ko.Computed<string>;
     public currentHandCaption: ko.Computed<string>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing runtime errors that could occur when hand history data is unavailable or not yet loaded. The application now properly handles cases where historical hand records are not present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->